### PR TITLE
Forcing get-pip.py version to support Python 3.5

### DIFF
--- a/src/ESXi/PlanScripts/AddHosttovcenterserver-DeployPS-HPE-Legacy
+++ b/src/ESXi/PlanScripts/AddHosttovcenterserver-DeployPS-HPE-Legacy
@@ -118,7 +118,10 @@ EOF
 esxcli network firewall ruleset set -e true -r httpClient
 
 # Downloading get-pip.py 
-wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py
+# This script does not work on Python 3.5 (default in ESXi 7.0.0) 
+# The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/3.5/get-pip.py instead.
+# wget -O get-pip.py https://bootstrap.pypa.io/get-pip.py
+wget -O get-pip.py  https://bootstrap.pypa.io/pip/3.5/get-pip.py
 
 # Installing pip
 python3 get-pip.py


### PR DESCRIPTION
get-pip.py script has been updated and it no longer works on Python 3.5 (version running in ESXi 7.0) 
So we have to use https://bootstrap.pypa.io/pip/3.5/get-pip.py instead.
